### PR TITLE
Refactor useUrlState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,16 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+import { SearchParamsProvider } from './useUrlState';
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <App />
+    <SearchParamsProvider>
+      <App />
+    </SearchParamsProvider>
   </React.StrictMode>,
 );
 

--- a/src/useUrlState/index.js
+++ b/src/useUrlState/index.js
@@ -1,3 +1,6 @@
-import useUrlState from './useUrlState';
+import useUrlState from "./useUrlState";
+
+import { SearchParamsProvider } from "./useSearchParams";
 
 export default useUrlState;
+export { SearchParamsProvider };

--- a/src/useUrlState/useNavigate.js
+++ b/src/useUrlState/useNavigate.js
@@ -1,0 +1,19 @@
+import { useCallback } from "react";
+
+import { isBrowser } from "./util";
+
+function useNavigate() {
+  const navigate = useCallback((url, replace = false) => {
+    if (!isBrowser()) return;
+
+    const method = replace ? "replaceState" : "pushState";
+
+    window.history[method]({}, "", url);
+
+    window.dispatchEvent(new Event("popstate"));
+  }, []);
+
+  return navigate;
+}
+
+export default useNavigate;

--- a/src/useUrlState/useSearchParams.js
+++ b/src/useUrlState/useSearchParams.js
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { isBrowser } from "./util";
+
+function useWindowListener(eventType, listener) {
+  useEffect(() => {
+    if (!isBrowser()) return;
+
+    window.addEventListener(eventType, listener);
+
+    return () => {
+      window.removeEventListener(eventType, listener);
+    };
+  }, [eventType, listener]);
+}
+
+function getCurrentSearchParams() {
+  const search = isBrowser() ? window.location.search : "";
+  return new URLSearchParams(search);
+}
+
+const SearchParamsContext = createContext(getCurrentSearchParams());
+
+function SearchParamsProvider({ children }) {
+  const [searchParams, setSearchParams] = useState(getCurrentSearchParams());
+
+  useWindowListener("popstate", () => {
+    setSearchParams(getCurrentSearchParams());
+  });
+
+  return (
+    <SearchParamsContext.Provider value={searchParams}>
+      {children}
+    </SearchParamsContext.Provider>
+  );
+}
+
+function useSearchParams() {
+  return useContext(SearchParamsContext);
+}
+
+export default useSearchParams;
+export { SearchParamsProvider };


### PR DESCRIPTION
* Add `useSearchParams` Context hook
* Add `useNavigate` hook for imperative navigation
* Add support for parsing query string array type of repeated keys: `foo=bar&foo=tiger` => `{ foo: ['bar', 'tiger']}`
* Improve `parseStringArray`, remove dependency on `JSON.parse`